### PR TITLE
Feature/decoupler v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "scanpy>=1.9.3,<1.10.0",
     "torch-geometric>=2.2.0",
     "omnipath>=1.0.7",
-    "decoupler>=1.4.0",
+    "decoupler>=1.4.0,<2",
     "numpy<2",
 ]
 optional-dependencies.dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ optional-dependencies.benchmarking = [
     "scib-metrics>=0.3.3",
     "pynndescent>=0.5.8",
     "scikit-misc>=0.3.0",
-    "squidpy>=1.2.2",
+    "squidpy==1.2.3",
     "jax==0.4.7",
     "jaxlib==0.4.7"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "scanpy>=1.9.3,<1.10.0",
     "torch-geometric>=2.2.0",
     "omnipath>=1.0.7",
-    "decoupler>=1.4.0,<2",
+    "decoupler>=2.0.0",
     "numpy<2",
 ]
 optional-dependencies.dev = [

--- a/src/nichecompass/utils/gene_programs.py
+++ b/src/nichecompass/utils/gene_programs.py
@@ -329,7 +329,7 @@ def extract_gp_dict_from_collectri_tf_network(
         'target_gene').
     """
     if not load_from_disk:
-        net = dc.get_collectri(organism=species, split_complexes=False)
+        net = dc.op.collectri(organism=species, remove_complexes=False)
         if save_to_disk:
             net.to_csv(tf_network_file_path, index=False)
     else:


### PR DESCRIPTION
Fix #113
The keyword argument `split_complexes` has been changed to `remove_complexes` and the behaviour is slightly different.
Please check and choose `True` or `False` on your side. (@sebastianbirk)
Reference: (https://github.com/scverse/decoupler/commit/e5005769b123539b6b3c2d1b724554b84f25001f)